### PR TITLE
Refactor MaterialIcon into arrow function

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "prepublish": "babel --plugins transform-es2015-modules-umd src --ignore __tests__ --copy-files --out-dir ./dist",
+    "build": "npm run test && babel --plugins transform-es2015-modules-umd src --ignore __tests__ --copy-files --out-dir ./dist",
     "lint": "eslint ./src",
     "lintfix": "eslint ./src --fix",
     "testonly": "mocha $npm_package_options_mocha",

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,16 @@ import React from 'react';
 import './index.css';
 import { sizes, light, dark, mdInactive } from './config/mappings'
 
-class MaterialIcon extends React.Component {
-    render() {
-        const { icon, size, invert, inactive, color } = this.props; 
-
-        const sizeMapped = sizes[size] || parseInt(size) || sizes['small'];
-        const defaultColor = (invert && 'invert') ? light : dark;
-        const inactiveColor = (inactive && 'inactive') ? mdInactive : '';
-
-        const styleOverride = {color: color ? color : '', fontSize: sizeMapped};
-
-        return (
-            <i className={`material-icons ${sizeMapped} ${defaultColor} ${inactiveColor}`} style={styleOverride} >{icon}</i>
-        )
-    }
-};
+const MaterialIcon = ({ icon, size, invert, inactive, color }) => {
+    const sizeMapped = sizes[size] || parseInt(size) || sizes['small'];
+    const defaultColor = (invert && 'invert') ? light : dark;
+    const inactiveColor = (inactive && 'inactive') ? mdInactive : '';
+    const styleOverride = {color: color ? color : '', fontSize: sizeMapped};
+    
+    return (
+        <i className={`material-icons ${sizeMapped} ${defaultColor} ${inactiveColor}`} style={styleOverride} >{icon}</i>
+    )
+}
 
 export default MaterialIcon;
 export * from './pallet';


### PR DESCRIPTION
References #4 

As suggested in various docs, for stateless components, arrow functions are recommended as it makes the code less verbose and also is better optimized by React. Ref links and discussion in the issue.

It passes all tests and I've also ran it through a simple React app, works same as before, even with the code change.  

@sithumn Please review